### PR TITLE
Fix the bounce matching logic

### DIFF
--- a/aprs-server-core/src/bounce_matches.rs
+++ b/aprs-server-core/src/bounce_matches.rs
@@ -14,11 +14,10 @@ where
         data: _,
     } = bounce;
 
-    let team_matches = || client.get_team_id() != sender_team_id;
+    let team_matches = || client.get_team_id() == sender_team_id;
     let game_matches = || games.iter().any(|game| game == client.get_game());
-    let team_and_game_matches = || team_matches() && game_matches();
     let tag_matches = || tags.iter().any(|tag| client.has_tag(tag));
     let slot_matches = || slots.contains(&client.get_slot_id());
 
-    team_and_game_matches() || tag_matches() || slot_matches()
+    team_matches() && (game_matches() || tag_matches() || slot_matches())
 }


### PR DESCRIPTION
`team_matches` was doing the opposite and reporting when teams didn't match.

The upstream logic is `team_matches and (...)`:

```
if client.team == bounceclient.team and (ctx.games[bounceclient.slot] in games or
                                         set(bounceclient.tags) & tags or
                                         bounceclient.slot in slots):
```

The previous code was missing those parenthesis

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/aprs/2)
<!-- Reviewable:end -->
